### PR TITLE
Add planning/todos and clarification capabilities

### DIFF
--- a/server.py
+++ b/server.py
@@ -42,6 +42,7 @@ import tools.file_tools
 import tools.shell_tools
 import tools.search_tools
 import tools.web_tools
+import tools.planning_tools
 
 load_dotenv(Path(__file__).parent / '.env')
 
@@ -56,6 +57,7 @@ tools.file_tools.register(_sandbox)
 tools.shell_tools.register(_sandbox)
 tools.search_tools.register(_sandbox)
 tools.web_tools.register()
+tools.planning_tools.register()
 
 MAX_TOOL_ITERATIONS = 10
 
@@ -141,8 +143,33 @@ _CAPABILITIES = (
     '- /forget <id> : delete a memory entry\n'
     '- Mode and model switching via UI dropdowns\n'
     '- Conversation save/load/delete, response regeneration, thumbs up/down evaluation\n'
-    '\nYou also have tool-use capabilities for file operations, shell commands, and code search.\n'
-    'Use tools when the user asks you to read, write, edit, search, or run commands.\n'
+    '\nYou also have tool-use capabilities for file operations, shell commands, code search, '
+    'web search/fetch, and planning/task management.\n'
+    'Use tools when the user asks you to read, write, edit, search, run commands, or work through tasks.\n'
+)
+
+_PLANNING_BEHAVIOR = (
+    'Planning and task management:\n'
+    '- For any non-trivial task (research, multi-step work, analysis), create a plan FIRST using create_plan.\n'
+    '- Break complex requests into concrete, ordered steps.\n'
+    '- Update task status as you work: mark tasks in_progress when you start, completed when done, '
+    'blocked when stuck.\n'
+    '- If new work emerges during execution, use add_task to track it.\n'
+    '- Show the user your plan before executing it. This makes your work transparent and reviewable.\n'
+)
+
+_CLARIFICATION_BEHAVIOR = (
+    'Clarification protocol:\n'
+    '- Before diving into a complex or ambiguous request, ask 2-4 clarifying questions.\n'
+    '- Ask when: the scope is unclear, multiple valid interpretations exist, important constraints '
+    'are missing, or the request could go in very different directions.\n'
+    '- Do NOT ask when: the request is simple, specific, and unambiguous.\n'
+    '- Frame questions concisely. Number them. Wait for answers before proceeding.\n'
+    '- Example: "Before I start, a few questions:\\n'
+    '1. Do you want X or Y approach?\\n'
+    '2. Should I prioritize A or B?\\n'
+    '3. Any constraints I should know about?"\n'
+    '- After receiving answers, create a plan that reflects the clarified requirements, then execute.\n'
 )
 
 _BEHAVIORAL_CORE = (
@@ -175,6 +202,8 @@ MODES = {
             'run shell commands, search codebases, fetch web pages, and remember things across conversations."\n\n'
             + _CAPABILITIES + '\n'
             + _BEHAVIORAL_CORE + '\n'
+            + _CLARIFICATION_BEHAVIOR + '\n'
+            + _PLANNING_BEHAVIOR + '\n'
             'Mode: Default. Balanced tone. Provide clear, accurate, concise responses.'
         ),
         'temperature': 0.7,
@@ -187,6 +216,8 @@ MODES = {
             'You are Nemo, the ThinxAI technical assistant running on NVIDIA Nemotron.\n\n'
             + _CAPABILITIES + '\n'
             + _BEHAVIORAL_CORE + '\n'
+            + _CLARIFICATION_BEHAVIOR + '\n'
+            + _PLANNING_BEHAVIOR + '\n'
             'Mode: Technical. Prioritize accuracy over brevity. Include code examples when relevant. '
             'Use structured formatting (headers, lists, code blocks). '
             'Distinguish established facts from inferences.'
@@ -201,6 +232,8 @@ MODES = {
             'You are Nemo, the ThinxAI creative assistant running on NVIDIA Nemotron.\n\n'
             + _CAPABILITIES + '\n'
             + _BEHAVIORAL_CORE + '\n'
+            + _CLARIFICATION_BEHAVIOR + '\n'
+            + _PLANNING_BEHAVIOR + '\n'
             'Mode: Creative. Write with vivid language, varied sentence structure, and narrative flow. '
             'Take creative risks. Explore ideas from unexpected angles.'
         ),
@@ -214,6 +247,8 @@ MODES = {
             'You are Nemo, the ThinxAI research assistant running on NVIDIA Nemotron.\n\n'
             + _CAPABILITIES + '\n'
             + _BEHAVIORAL_CORE + '\n'
+            + _CLARIFICATION_BEHAVIOR + '\n'
+            + _PLANNING_BEHAVIOR + '\n'
             'Mode: Research. Analyze claims carefully. Distinguish evidence from inference. '
             'Cite reasoning steps explicitly. Flag assumptions. '
             'When uncertain, state so clearly rather than speculating.'

--- a/tools/planning_tools.py
+++ b/tools/planning_tools.py
@@ -1,0 +1,191 @@
+"""Planning and task management tools for structured work breakdown."""
+
+from __future__ import annotations
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from tools.registry import ToolDef, TOOL_REGISTRY
+
+PLANS_DIR = Path(__file__).parent.parent / 'plans'
+PLANS_DIR.mkdir(exist_ok=True)
+
+VALID_STATUSES = ('pending', 'in_progress', 'completed', 'blocked')
+
+
+def _current_plan_path() -> Path:
+    return PLANS_DIR / '_current.json'
+
+
+def _load_plan(name: str | None = None) -> dict | None:
+    if name:
+        path = PLANS_DIR / f'{name}.json'
+    else:
+        path = _current_plan_path()
+    if not path.exists():
+        return None
+    return json.loads(path.read_text())
+
+
+def _save_plan(plan: dict, name: str | None = None):
+    plan['updated'] = datetime.now(timezone.utc).isoformat()
+    if name:
+        path = PLANS_DIR / f'{name}.json'
+    else:
+        path = _current_plan_path()
+    path.write_text(json.dumps(plan, indent=2))
+
+
+def register():
+    """Register planning tools with the global registry."""
+
+    async def create_plan(name: str, goal: str, tasks: str) -> dict:
+        """Create a new plan. tasks is a pipe-separated list of task descriptions."""
+        safe_name = ''.join(c for c in name if c.isalnum() or c in '-_').lower()
+        if not safe_name:
+            return {'error': 'Invalid plan name'}
+
+        task_list = [t.strip() for t in tasks.split('|') if t.strip()]
+        if not task_list:
+            return {'error': 'No tasks provided. Separate tasks with | characters.'}
+
+        plan = {
+            'name': safe_name,
+            'goal': goal,
+            'created': datetime.now(timezone.utc).isoformat(),
+            'updated': datetime.now(timezone.utc).isoformat(),
+            'tasks': [
+                {'id': i + 1, 'description': desc, 'status': 'pending', 'notes': ''}
+                for i, desc in enumerate(task_list)
+            ],
+        }
+
+        _save_plan(plan, safe_name)
+        _save_plan(plan)  # also set as current
+        return {'message': f'Plan "{safe_name}" created with {len(task_list)} tasks', 'plan': plan}
+
+    async def get_plan(name: str = '') -> dict:
+        """Get a plan by name, or the current plan if no name given."""
+        plan = _load_plan(name if name else None)
+        if not plan:
+            label = f'Plan "{name}"' if name else 'No current plan'
+            return {'error': f'{label} not found'}
+        return {'plan': plan}
+
+    async def update_task(task_id: str, status: str, notes: str = '') -> dict:
+        """Update a task's status in the current plan."""
+        plan = _load_plan()
+        if not plan:
+            return {'error': 'No current plan. Create one first with create_plan.'}
+
+        if status not in VALID_STATUSES:
+            return {'error': f'Invalid status "{status}". Must be one of: {", ".join(VALID_STATUSES)}'}
+
+        tid = int(task_id)
+        for task in plan['tasks']:
+            if task['id'] == tid:
+                task['status'] = status
+                if notes:
+                    task['notes'] = notes
+                _save_plan(plan)
+                _save_plan(plan, plan['name'])
+                return {'message': f'Task {tid} updated to {status}', 'task': task}
+
+        return {'error': f'Task {tid} not found in plan'}
+
+    async def add_task(description: str, after_task_id: str = '') -> dict:
+        """Add a task to the current plan."""
+        plan = _load_plan()
+        if not plan:
+            return {'error': 'No current plan. Create one first with create_plan.'}
+
+        max_id = max(t['id'] for t in plan['tasks']) if plan['tasks'] else 0
+        new_task = {'id': max_id + 1, 'description': description, 'status': 'pending', 'notes': ''}
+
+        if after_task_id:
+            idx = next((i for i, t in enumerate(plan['tasks']) if t['id'] == int(after_task_id)), None)
+            if idx is not None:
+                plan['tasks'].insert(idx + 1, new_task)
+            else:
+                plan['tasks'].append(new_task)
+        else:
+            plan['tasks'].append(new_task)
+
+        _save_plan(plan)
+        _save_plan(plan, plan['name'])
+        return {'message': f'Task {new_task["id"]} added: {description}', 'task': new_task}
+
+    async def list_plans() -> dict:
+        """List all saved plans."""
+        plans = []
+        for f in sorted(PLANS_DIR.glob('*.json')):
+            if f.name == '_current.json':
+                continue
+            try:
+                p = json.loads(f.read_text())
+                total = len(p.get('tasks', []))
+                done = sum(1 for t in p.get('tasks', []) if t['status'] == 'completed')
+                plans.append({
+                    'name': p.get('name', f.stem),
+                    'goal': p.get('goal', ''),
+                    'progress': f'{done}/{total}',
+                    'updated': p.get('updated', ''),
+                })
+            except Exception:
+                continue
+        if not plans:
+            return {'message': 'No plans found'}
+        return {'plans': plans}
+
+    # Register all tools
+    TOOL_REGISTRY.register(ToolDef(
+        name='create_plan',
+        description='Create a structured plan with a goal and task list. Use this when starting any non-trivial task to organize your work.',
+        parameters={
+            'name': {'type': 'string', 'description': 'Short plan name (alphanumeric, hyphens, underscores)'},
+            'goal': {'type': 'string', 'description': 'What this plan aims to accomplish'},
+            'tasks': {'type': 'string', 'description': 'Pipe-separated list of tasks, e.g. "Research topic | Draft outline | Write content"'},
+        },
+        handler=create_plan,
+    ))
+
+    TOOL_REGISTRY.register(ToolDef(
+        name='get_plan',
+        description='View the current plan or a named plan. Shows all tasks with their status.',
+        parameters={
+            'name': {'type': 'string', 'description': 'Plan name to view (empty for current plan)'},
+        },
+        required=[],
+        handler=get_plan,
+    ))
+
+    TOOL_REGISTRY.register(ToolDef(
+        name='update_task',
+        description='Update a task status in the current plan. Mark tasks as you work through them.',
+        parameters={
+            'task_id': {'type': 'string', 'description': 'Task ID number'},
+            'status': {'type': 'string', 'description': 'New status: pending, in_progress, completed, or blocked'},
+            'notes': {'type': 'string', 'description': 'Optional notes about progress or blockers'},
+        },
+        required=['task_id', 'status'],
+        handler=update_task,
+    ))
+
+    TOOL_REGISTRY.register(ToolDef(
+        name='add_task',
+        description='Add a new task to the current plan. Use when you discover additional work needed.',
+        parameters={
+            'description': {'type': 'string', 'description': 'Task description'},
+            'after_task_id': {'type': 'string', 'description': 'Insert after this task ID (empty to append)'},
+        },
+        required=['description'],
+        handler=add_task,
+    ))
+
+    TOOL_REGISTRY.register(ToolDef(
+        name='list_plans',
+        description='List all saved plans with their progress.',
+        parameters={},
+        required=[],
+        handler=list_plans,
+    ))


### PR DESCRIPTION
## Summary
- **Planning tools**: `create_plan`, `get_plan`, `update_task`, `add_task`, `list_plans` with JSON persistence in `plans/`
- **Clarification behavior**: System prompt instructs model to ask 2-4 clarifying questions before complex/ambiguous requests
- **Planning behavior**: System prompt instructs model to create structured plans for non-trivial work

Closes #6

## Test plan
- [ ] Restart server, verify new tools appear in system prompt
- [ ] Ask an ambiguous question, verify clarification questions
- [ ] Ask for a multi-step task, verify plan creation
- [ ] Check `plans/` directory for JSON persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)